### PR TITLE
Add failing test

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -315,3 +315,10 @@ test(
   '.one .two .three {} .one { .two { .three {} } }',
   '.one .two .three {}'
 );
+
+test(
+  'multiple properties',
+  processCSS,
+  '.a {color: black; height: 10px} .a {background-color: red; width: 20px}',
+  '.a {color: black; height: 10px; background-color: red; width: 20px}'
+);


### PR DESCRIPTION
When collapsing rules, all properties should be transferred.

Expected: .a {color: black; height: 10px; background-color: red; width: 20px}
Actual: .a {color: black; height: 10px; background-color: red}

I'm not sure how to fix this; consider it a bug report, with a method of reproducing it!