### PR TITLE
Move all declarations from old rule to new rule

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,8 +15,12 @@ export default postcss.plugin('postcss-combine-duplicated-selectors', () => {
     css.walkRules(rule => {
       const selector = uniformStyle.process(rule.selector).result;
       if (symbolTable.has(selector)) {
+        // store original rule as destination
+        const destination = symbolTable.get(selector);
         // move declarations to original rule
-        rule.nodes.forEach(decl => decl.moveTo(symbolTable.get(selector)));
+        while (rule.nodes.length > 0) {
+          rule.nodes[0].moveTo(destination);
+        }
         // remove duplicated rule
         rule.remove();
       } else {

--- a/test/index.js
+++ b/test/index.js
@@ -318,7 +318,7 @@ test(
 
 test(
   'multiple properties',
-  processCSS,
+  [processCSS, processNestedCSS],
   '.a {color: black; height: 10px} .a {background-color: red; width: 20px}',
   '.a {color: black; height: 10px; background-color: red; width: 20px}'
 );


### PR DESCRIPTION
Resolves an issue where some items would be lost during copy.
This was being caused by `forEach` incrementing an internal counter while at the same time `moveTo` decreases the number of elements counted in length.

resolves #27 