### PR TITLE
1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-combine-duplicated-selectors",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "automatically keep css selectors unique",
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
Matching selectors that have different text order but same logical meaning are now grouped.

E.G.

``` css
.one.two {} .two.one {}
```

become

``` css
.one.two {}
```

**Testing**
* Added tests for different textual ordering
* Added tests for pseudo classes
* Added tests for psuedo elements
* Restructured tests to separate unique selector tests and duplicated selector tests
* Restructured tests to separate css tests from less/scss tests.

**Chores**
* Updated dependencies
* Added script to ensure release will always have latest built code