### PR TITLE
drop support for node 0.12

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,7 +2,9 @@
   "comments": false,
   "compact": true,
   "presets": [
-    "es2015",
     "stage-2"
+  ],
+  "plugins": [
+    "transform-es2015-modules-commonjs"
   ]
 }

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -2,5 +2,13 @@ extends:
   - google
   - plugin:import/errors
   - plugin:import/warnings
+  - plugin:node/recommended
 plugins:
   - import
+  - node
+rules:
+  node/no-unsupported-features:
+    - error
+    - version: 4
+      ignores:
+        - modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,5 @@ language: node_js
 node_js:
   - 6
   - 4
-  - 0.12
 before_install:
   - npm i -g npm@latest

--- a/package.json
+++ b/package.json
@@ -37,12 +37,13 @@
     "ava": "^0.15.2",
     "babel-cli": "^6.10.1",
     "babel-core": "^6.10.4",
-    "babel-preset-es2015": "^6.9.0",
-    "babel-preset-stage-2": "^6.5.0",
-    "eslint": "^2.13.1",
+    "babel-plugin-transform-es2015-modules-commonjs": "^6.10.3",
+    "babel-preset-stage-2": "^6.11.0",
+    "eslint": "^3.0.0",
     "eslint-config-google": "^0.6.0",
     "eslint-plugin-ava": "^2.5.0",
-    "eslint-plugin-import": "^1.9.2",
+    "eslint-plugin-import": "^1.10.0",
+    "eslint-plugin-node": "^1.5.2",
     "postcss-less": "^0.13.0",
     "postcss-nested": "^1.0.0",
     "postcss-scss": "^0.1.8",
@@ -51,6 +52,6 @@
     "rimraf": "^2.5.2"
   },
   "engines": {
-    "node": ">=0.12"
+    "node": ">=4"
   }
 }


### PR DESCRIPTION
LTS for 0.12 is over maintenance ends this December.
Removing support reduces the number of transforms that need to release code.