### PR TITLE
chore(travis): remove greenkeeper lockfile upload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: node_js
 node_js:
   - 6
   - 8
-dist: trusty
-sudo: false
+
 before_install: npm i -g greenkeeper-lockfile@1
 before_script: greenkeeper-lockfile-update
-after_script: greenkeeper-lockfile-upload


### PR DESCRIPTION
There is a risk of leaking write key to make this work, without the write key it will fail.