### PR TITLE
refactor: better leverage postcss 8 visitor API to walk the syntax tree once

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -70,61 +70,71 @@ module.exports = (options) => {
   options = Object.assign({}, defaultOptions, options);
   return {
     postcssPlugin: name,
-    Once: (css) => {
+    prepare() {
       // Create a map to store maps
       const mapTable = new Map();
       // root map to store root selectors
       mapTable.set('root', new Map());
 
-      css.walkRules((rule) => {
-        let map;
-        // Check selector parent for any at rule
-        if (rule.parent.type === 'atrule') {
-          // Use name and query params as the key
-          const query =
-            rule.parent.name.toLowerCase() +
-            rule.parent.params.replace(/\s+/g, '');
+      return {
+        Rule: (rule) => {
+          let map;
+          // Check selector parent for any at rule
+          if (rule.parent.type === 'atrule') {
+            // Use name and query params as the key
+            const query =
+              rule.parent.name.toLowerCase() +
+              rule.parent.params.replace(/\s+/g, '');
 
-          // See if this query key is already in the map table
-          map = mapTable.has(query) ? // If it is use it
-            mapTable.get(query) : // if not set it and get it
-            mapTable.set(query, new Map()).get(query);
-        } else {
-          // Otherwise we are dealing with a selector in the root
-          map = mapTable.get('root');
-        }
-
-        const selector = uniformStyle.processSync(rule.selector, {
-          lossless: false,
-        });
-
-        if (map.has(selector)) {
-          // store original rule as destination
-          const destination = map.get(selector);
-          // move declarations to original rule
-          while (rule.nodes.length > 0) {
-            destination.append(rule.nodes[0]);
+            // See if this query key is already in the map table
+            map = mapTable.has(query) ? // If it is use it
+              mapTable.get(query) : // if not set it and get it
+              mapTable.set(query, new Map()).get(query);
+          } else {
+            // Otherwise we are dealing with a selector in the root
+            map = mapTable.get('root');
           }
-          // remove duplicated rule
-          rule.remove();
 
-          if (
-            options.removeDuplicatedProperties ||
-            options.removeDuplicatedValues
-          ) {
-            removeDupProperties(destination, options.removeDuplicatedValues);
+          // create a uniform selector
+          const selector = uniformStyle.processSync(rule.selector, {
+            lossless: false,
+          });
+
+          if (map.has(selector)) {
+            // store original rule as destination
+            const destination = map.get(selector);
+
+            // check if node has already been processed
+            if (destination === rule) return;
+
+            // move declarations to original rule
+            while (rule.nodes.length > 0) {
+              destination.append(rule.nodes[0]);
+            }
+            // remove duplicated rule
+            rule.remove();
+
+            if (
+              options.removeDuplicatedProperties ||
+              options.removeDuplicatedValues
+            ) {
+              removeDupProperties(
+                  destination,
+                  options.removeDuplicatedValues,
+              );
+            }
+          } else {
+            if (
+              options.removeDuplicatedProperties ||
+              options.removeDuplicatedValues
+            ) {
+              removeDupProperties(rule, options.removeDuplicatedValues);
+            }
+            // add new selector to symbol table
+            map.set(selector, rule);
           }
-        } else {
-          if (
-            options.removeDuplicatedProperties ||
-            options.removeDuplicatedValues
-          ) {
-            removeDupProperties(rule, options.removeDuplicatedValues);
-          }
-          // add new selector to symbol table
-          map.set(selector, rule);
-        }
-      });
+        },
+      };
     },
   };
 };


### PR DESCRIPTION
for more information on the new tree walking API see: https://evilmartians.com/chronicles/postcss-8-plugin-migration#step-3-take-the-most-out-of-the-new-api and https://github.com/postcss/postcss/releases/tag/8.0.0