### PR TITLE
refactor: optimize remove duplicated properties

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -40,14 +40,32 @@ function sortGroups(selector) {
  * @param {Boolean} exact
  */
 function removeDupProperties(selector, exact) {
-  // Remove duplicated properties from bottom to top ()
-  for (let actIndex = selector.nodes.length - 1; actIndex >= 1; actIndex--) {
-    for (let befIndex = actIndex - 1; befIndex >= 0; befIndex--) {
-      if (selector.nodes[actIndex].prop === selector.nodes[befIndex].prop) {
+  if (!exact) { // Remove duplicated properties, regardless of value
+    const lastIndices = new Map(); // stores the last index at which each prop is found
+    const indicesToRemove = []; // list of indices to remove in descending order
+
+    for (let actIndex = selector.nodes.length - 1; actIndex >= 1; actIndex--) {
+      const prop = selector.nodes[actIndex].prop;
+      if (prop !== undefined) {
+        if (!lastIndices.has(prop)) {
+          lastIndices.set(prop, actIndex); // Store the last occurrence of the prop - it will be kept
+        } else {
+          indicesToRemove.push(actIndex); // This occurrence of the prop must be removed
+        }
+      }
+    }
+
+    // Indeces to be removed are already sorted from biggest to last
+    indicesToRemove.forEach(indexToRemove => {
+      selector.nodes[indexToRemove].remove();
+    });
+  } else {
+    // Remove duplicated properties from bottom to top ()
+    for (let actIndex = selector.nodes.length - 1; actIndex >= 1; actIndex--) {
+      for (let befIndex = actIndex - 1; befIndex >= 0; befIndex--) {
         if (
-          !exact ||
-          (exact &&
-            selector.nodes[actIndex].value === selector.nodes[befIndex].value)
+          selector.nodes[actIndex].prop === selector.nodes[befIndex].prop &&
+          selector.nodes[actIndex].value === selector.nodes[befIndex].value
         ) {
           selector.nodes[befIndex].remove();
           actIndex--;

--- a/src/index.js
+++ b/src/index.js
@@ -41,24 +41,18 @@ function sortGroups(selector) {
  */
 function removeDupProperties(selector, exact) {
   if (!exact) { // Remove duplicated properties, regardless of value
-    const lastIndices = new Map(); // stores the last index at which each prop is found
-    const indicesToRemove = []; // list of indices to remove in descending order
+    const retainedProps = new Set();
 
     for (let actIndex = selector.nodes.length - 1; actIndex >= 1; actIndex--) {
       const prop = selector.nodes[actIndex].prop;
       if (prop !== undefined) {
-        if (!lastIndices.has(prop)) {
-          lastIndices.set(prop, actIndex); // Store the last occurrence of the prop - it will be kept
+        if (!retainedProps.has(prop)) {
+          retainedProps.add(prop); // Mark the prop as retained, all other occurrences must be removed
         } else {
-          indicesToRemove.push(actIndex); // This occurrence of the prop must be removed
+          selector.nodes[actIndex].remove(); // This occurrence of the prop must be removed
         }
       }
     }
-
-    // Indeces to be removed are already sorted from biggest to last
-    indicesToRemove.forEach(indexToRemove => {
-      selector.nodes[indexToRemove].remove();
-    });
   } else {
     // Remove duplicated properties from bottom to top ()
     for (let actIndex = selector.nodes.length - 1; actIndex >= 1; actIndex--) {


### PR DESCRIPTION
When the `removeDuplicatedValues` configuration setting is set to `true`, it is unavoidable to have two embedded loops to remove duplicates, as both the props and the values must be compared.

However, if only `removeDuplicatedProperties` is set to `true`, then duplicates can be removed with only one loop - iterate from the last node to the first, keep the first occurrence of each prop (as it will be the last in the CSS selector), and remove all others.

For large, programmatically generated selectors, most commonly `:root { ... }` and hundreds of CSS variables inside, this optimization can reduce the time needed by the plugin by a minute or more.